### PR TITLE
feat(facade): unified Tx3ClientBuilder for §3.3/§3.6 parity

### DIFF
--- a/.trix/client-lib/protocol.go.hbs
+++ b/.trix/client-lib/protocol.go.hbs
@@ -4,11 +4,10 @@
 package protocol
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/tx3-lang/go-sdk/sdk/core"
+	"github.com/tx3-lang/go-sdk/sdk/facade"
 	"github.com/tx3-lang/go-sdk/sdk/trp"
 )
 
@@ -25,23 +24,27 @@ const (
 const EnvironmentSchema = `{{{json tii.environment}}}`
 
 {{/if}}
-// Profile holds the environment values and party addresses for a named TII profile.
-type Profile struct {
-	Environment core.EnvMap       `json:"environment"`
-	Parties     map[string]string `json:"parties"`
-}
+{{#if tii.profiles}}
+// Profile is the typed selector for an embedded profile.
+type Profile string
 
-const profilesJSON = `{{{json tii.profiles}}}`
+const (
+{{#each tii.profiles}}
+	Profile{{pascalCase @key}} Profile = "{{@key}}"
+{{/each}}
+)
 
-// Profiles enumerates the profiles embedded from the TII, keyed by name.
-var Profiles = func() map[string]Profile {
-	var parsed map[string]Profile
-	if err := json.Unmarshal([]byte(profilesJSON), &parsed); err != nil {
-		panic("codegen: invalid embedded profiles: " + err.Error())
+{{#each tii.profiles}}
+var _{{constantCase @key}}_PROFILE = func() facade.Profile {
+	var p facade.Profile
+	if err := json.Unmarshal([]byte(`{{{json this}}}`), &p); err != nil {
+		panic("codegen: invalid embedded {{@key}} profile: " + err.Error())
 	}
-	return parsed
+	return p
 }()
+{{/each}}
 
+{{/if}}
 {{#each tii.transactions}}
 // {{pascalCase @key}}Params holds the arguments for the {{@key}} transaction.
 type {{pascalCase @key}}Params struct {
@@ -58,46 +61,67 @@ var {{constantCase @key}}_TIR = core.TirEnvelope{
 }
 
 {{/each}}
-// Client is a thin protocol facade over the TRP client.
+// Client is a typed protocol facade wrapping facade.Tx3Client.
+//
+// All lifecycle state, party storage, resolve/sign/submit/wait, and error
+// handling live in the SDK. This wrapper only adds the typed shape of
+// per-transaction methods, per-party setters, and the embedded protocol
+// fragments.
 type Client struct {
-	trp     *trp.Client
-	profile *Profile
+	inner *facade.Tx3Client
 }
 
-// NewClient creates a Client over the given TRP client options.
-func NewClient(options trp.ClientOptions) *Client {
-	return &Client{trp: trp.NewClient(options)}
-}
-
-// WithProfile selects an embedded profile by name. Its environment values and
-// party addresses are applied to every subsequent transaction. It panics if
-// name is not a profile declared by the protocol.
-func (c *Client) WithProfile(name string) *Client {
-	profile, ok := Profiles[name]
-	if !ok {
-		panic(fmt.Sprintf("unknown profile %q", name))
+// NewClient creates a Client over the given TRP options{{#if tii.profiles}} and profile{{/if}}.
+//
+// The profile is locked in at construction; switching profiles requires a new Client.
+func NewClient(options trp.ClientOptions{{#if tii.profiles}}, profile Profile{{/if}}) *Client {
+	transactions := map[string]core.TirEnvelope{
+{{#each tii.transactions}}
+		"{{@key}}": {{constantCase @key}}_TIR,
+{{/each}}
 	}
-	c.profile = &profile
+{{#if tii.profiles}}
+	profiles := map[string]facade.Profile{
+{{#each tii.profiles}}
+		"{{@key}}": _{{constantCase @key}}_PROFILE,
+{{/each}}
+	}
+{{else}}
+	profiles := map[string]facade.Profile{}
+{{/if}}
+
+	builder := facade.FromParts(transactions, profiles, nil).TRP(options)
+{{#if tii.profiles}}
+	builder = builder.WithProfile(string(profile))
+{{/if}}
+	inner, err := builder.Build()
+	if err != nil {
+		// Codegen invariant: the embedded protocol is internally consistent,
+		// so the only failure path is the caller-supplied options.
+		panic("codegen: builder construction failed: " + err.Error())
+	}
+	return &Client{inner: inner}
+}
+
+{{#each tii.parties}}
+// With{{pascalCase @key}} binds the {{@key}} party (signer or read-only address).
+// Overrides any address declared for that party by the selected profile.
+func (c *Client) With{{pascalCase @key}}(party facade.Party) *Client {
+	c.inner = c.inner.WithPartyUnchecked("{{@key}}", party)
 	return c
 }
 
-func (c *Client) resolve(ctx context.Context, tir core.TirEnvelope, args core.ArgMap) (*trp.TxEnvelope, error) {
-	params := trp.ResolveParams{Tir: tir, Args: args}
-	if c.profile != nil {
-		params.Env = c.profile.Environment
-		for name, address := range c.profile.Parties {
-			if _, set := args[name]; !set {
-				args[name] = address
-			}
-		}
-	}
-	return c.trp.Resolve(ctx, params)
-}
-
+{{/each}}
 {{#each tii.transactions}}
-// {{pascalCase @key}} resolves the {{@key}} transaction.
-func (c *Client) {{pascalCase @key}}(ctx context.Context, args {{pascalCase @key}}Params) (*trp.TxEnvelope, error) {
-	return c.resolve(ctx, {{constantCase @key}}_TIR, core.ArgMap{
+// {{pascalCase @key}} builds the {{@key}} transaction. Drive the returned builder with
+// .Resolve(ctx) and the rest of the lifecycle chain.
+func (c *Client) {{pascalCase @key}}(args {{pascalCase @key}}Params) *facade.TxBuilder {
+	b, err := c.inner.Tx("{{@key}}")
+	if err != nil {
+		// Codegen invariant: the embedded "{{@key}}" TIR is always declared.
+		panic("codegen: tx \"{{@key}}\" missing from embedded protocol")
+	}
+	return b.Args(map[string]interface{}{
 {{#each params.properties}}
 		"{{@key}}": args.{{pascalCase @key}},
 {{/each}}
@@ -105,7 +129,3 @@ func (c *Client) {{pascalCase @key}}(ctx context.Context, args {{pascalCase @key
 }
 
 {{/each}}
-// Submit sends a signed transaction to the network.
-func (c *Client) Submit(ctx context.Context, params trp.SubmitParams) (*trp.SubmitResponse, error) {
-	return c.trp.Submit(ctx, params)
-}

--- a/README.md
+++ b/README.md
@@ -35,18 +35,13 @@ import (
 )
 
 func main() {
-    // Load a compiled .tii protocol
+    // 1. Load a compiled .tii protocol
     protocol, err := tx3.ProtocolFromFile("transfer.tii")
     if err != nil {
         log.Fatal(err)
     }
 
-    // Connect to a TRP server
-    trpClient := tx3.NewTRPClient(trp.ClientOptions{
-        Endpoint: "http://localhost:3000",
-    })
-
-    // Create a Cardano signer from a mnemonic
+    // 2. Build a Cardano signer from a mnemonic
     mySigner, err := signer.CardanoSignerFromMnemonic(
         "addr_test1qz...",
         "word1 word2 ... word24",
@@ -55,21 +50,37 @@ func main() {
         log.Fatal(err)
     }
 
-    // Configure client with profile and parties
-    client := tx3.NewClient(protocol, trpClient).
+    // 3. Build a client: configure TRP, profile, and parties on the builder
+    client, err := tx3.ProtocolClient(protocol).
+        TRP(trp.ClientOptions{Endpoint: "http://localhost:3000"}).
         WithProfile("preprod").
         WithParty("sender", tx3.SignerParty(mySigner)).
-        WithParty("receiver", tx3.AddressParty("addr_test1qz..."))
+        WithParty("receiver", tx3.AddressParty("addr_test1qz...")).
+        Build()
+    if err != nil {
+        log.Fatal(err)
+    }
 
     ctx := context.Background()
 
-    // Build, resolve, sign, submit, and wait for confirmation
-    status, err := client.Tx("transfer").
-        Arg("quantity", 10_000_000).
-        Resolve(ctx)         // -> ResolvedTx
-        .Sign()              // -> SignedTx
-        .Submit(ctx)         // -> SubmittedTx
-        .WaitForConfirmed(ctx, tx3.DefaultPollConfig())
+    // 4. Build, resolve, sign, submit, and wait for confirmation
+    txb, err := client.Tx("transfer")
+    if err != nil {
+        log.Fatal(err)
+    }
+    resolved, err := txb.Arg("quantity", 10_000_000).Resolve(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    signed, err := resolved.Sign()
+    if err != nil {
+        log.Fatal(err)
+    }
+    submitted, err := signed.Submit(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    status, err := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())
     if err != nil {
         log.Fatal(err)
     }
@@ -78,16 +89,29 @@ func main() {
 }
 ```
 
-> **Note:** The quick-start example above shows the conceptual flow. In real code, check errors at each step since Go doesn't chain errors across method calls.
+All fallible validation — TRP endpoint present, profile declared, every bound
+party declared — happens inside `Build()`, which returns `*MissingTrpEndpointError`,
+`*tii.UnknownProfileError`, or `*facade.UnknownPartyError` (all discriminable via
+`errors.As`). Optional setters never fail, so chains stay fluent. Profile selection
+is **builder-only**: there is no profile-switching method on the built client.
+Switching profiles requires a new builder.
+
+> **Note on naming:** Go uses the cross-package factory `tx3.ProtocolClient(p)`
+> (equivalently `facade.FromProtocol(p)`) instead of a `Protocol.Client()` method
+> to avoid a `tii → facade → tii` import cycle. Other SDKs (web, python) do
+> expose `Protocol.client()`.
 
 ## Concepts
 
 | SDK Type | Glossary Term | Description |
 |---|---|---|
 | `Protocol` | TII / Protocol | Loaded `.tii` file exposing transactions, parties, and profiles |
-| `Tx3Client` | Facade | Entry point holding protocol, TRP client, and party bindings |
-| `TxBuilder` | Invocation builder | Collects args, resolves via TRP |
+| `Tx3ClientBuilder` | Client builder | Fluent builder seeded by `tx3.ProtocolClient(p)` or `facade.FromParts(...)`; absorbs all fallible validation in `Build()` |
+| `Tx3Client` | Facade | Output of `Tx3ClientBuilder.Build()` — owns the deconstructed protocol parts, TRP client, profile, and party bindings |
+| `TxBuilder` | Invocation builder | Source-agnostic; collects args, resolves via TRP |
 | `Party` | Party | Named participant — `AddressParty` (read-only) or `SignerParty` (signing) |
+| `Profile` | Profile | `{Environment, Parties}` value baked into the client; embedded by codegen plugins, decomposed from `Protocol` by `FromProtocol` |
+| `MissingTrpEndpointError` / `UnknownPartyError` | Builder errors | Returned by `Build()`; implement the `facade.FacadeError` marker |
 | `Signer` | Signer | Interface producing a `TxWitness` for a `SignRequest` |
 | `SignRequest` | SignRequest | Input passed to `Signer.Sign`: `TxHashHex` + `TxCborHex` |
 | `CardanoSigner` | Cardano Signer | BIP32-Ed25519 signer at `m/1852'/1815'/0'/0/0` |
@@ -98,6 +122,25 @@ func main() {
 | `PollConfig` | Poll configuration | Controls `WaitForConfirmed` / `WaitForFinalized` polling |
 
 ## Advanced usage
+
+### Skipping the runtime `.tii` (codegen flow)
+
+If you've run `trix codegen` to generate typed bindings, your generated `Client`
+embeds the per-transaction TIR envelopes and per-profile data at codegen time —
+no `.tii` artifact at runtime. Under the hood it seeds the same builder via
+`facade.FromParts(transactions, profiles, knownParties)` and routes typed
+per-party setters through `WithPartyUnchecked`. You can also call `FromParts`
+directly from hand-written code (`tx3.FromParts` is the same factory re-exported
+at the package root):
+
+```go
+import tx3 "github.com/tx3-lang/go-sdk/sdk"
+
+client, err := tx3.FromParts(transactions, profiles, []string{"sender", "receiver"}).
+    TRPEndpoint("http://localhost:3000").
+    WithPartyUnchecked("sender", tx3.SignerParty(mySigner)).
+    Build()
+```
 
 ### Low-level TRP client
 
@@ -165,12 +208,21 @@ submitted, err := signed.Submit(ctx)
 All errors are discriminable via `errors.As()` — no string matching needed:
 
 ```go
-import "github.com/tx3-lang/go-sdk/sdk/facade"
+import (
+    "github.com/tx3-lang/go-sdk/sdk/facade"
+    "github.com/tx3-lang/go-sdk/sdk/tii"
+)
 
-_, err := client.Tx("transfer").Resolve(ctx)
-var unknownParty *facade.UnknownPartyError
-if errors.As(err, &unknownParty) {
-    fmt.Printf("Party %q not found in protocol\n", unknownParty.Name)
+_, err := tx3.ProtocolClient(protocol).Build()
+var missingTRP *facade.MissingTrpEndpointError
+if errors.As(err, &missingTRP) {
+    // no TRP endpoint supplied via TRP() / TRPEndpoint()
+}
+
+_, err = client.Tx("transfer")
+var unknownTx *tii.UnknownTxError
+if errors.As(err, &unknownTx) {
+    fmt.Printf("Tx %q not declared by protocol\n", unknownTx.Name)
 }
 ```
 

--- a/sdk/e2e/e2e_test.go
+++ b/sdk/e2e/e2e_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tx3-lang/go-sdk/sdk/facade"
 	"github.com/tx3-lang/go-sdk/sdk/signer"
 	"github.com/tx3-lang/go-sdk/sdk/tii"
-	"github.com/tx3-lang/go-sdk/sdk/trp"
 )
 
 func skipIfNoTRP(t *testing.T) {
@@ -32,14 +31,6 @@ func skipIfNoTRP(t *testing.T) {
 	if os.Getenv("TRP_ENDPOINT_PREPROD") == "" {
 		t.Skip("TRP_ENDPOINT_PREPROD not set, skipping e2e test")
 	}
-}
-
-func trpHeadersFromEnv() map[string]string {
-	apiKey := os.Getenv("TRP_API_KEY_PREPROD")
-	if apiKey == "" {
-		return nil
-	}
-	return map[string]string{"dmtr-api-key": apiKey}
 }
 
 func requireEnv(t *testing.T, name string) string {
@@ -51,18 +42,30 @@ func requireEnv(t *testing.T, name string) string {
 	return v
 }
 
-func TestE2EHappyPath(t *testing.T) {
-	skipIfNoTRP(t)
-	endpoint := requireEnv(t, "TRP_ENDPOINT_PREPROD")
-	partyAAddr := requireEnv(t, "TEST_PARTY_A_ADDRESS")
-	partyAMnemonic := requireEnv(t, "TEST_PARTY_A_MNEMONIC")
-
+// e2eBuilder seeds a Tx3ClientBuilder from the test fixture and applies the
+// preprod profile + (optional) dmtr-api-key header from the environment.
+func e2eBuilder(t *testing.T, endpoint string) *facade.Tx3ClientBuilder {
+	t.Helper()
 	protocol, err := tii.FromFile("../testdata/transfer.tii")
 	if err != nil {
 		t.Fatalf("FromFile failed: %v", err)
 	}
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: endpoint, Headers: trpHeadersFromEnv()})
+	builder := facade.FromProtocol(protocol).
+		TRPEndpoint(endpoint).
+		WithProfile("preprod")
+
+	if apiKey := os.Getenv("TRP_API_KEY_PREPROD"); apiKey != "" {
+		builder = builder.WithHeader("dmtr-api-key", apiKey)
+	}
+	return builder
+}
+
+func TestE2EHappyPath(t *testing.T) {
+	skipIfNoTRP(t)
+	endpoint := requireEnv(t, "TRP_ENDPOINT_PREPROD")
+	partyAAddr := requireEnv(t, "TEST_PARTY_A_ADDRESS")
+	partyAMnemonic := requireEnv(t, "TEST_PARTY_A_MNEMONIC")
 
 	cardanoSigner, err := signer.CardanoSignerFromMnemonic(partyAAddr, partyAMnemonic)
 	if err != nil {
@@ -74,17 +77,23 @@ func TestE2EHappyPath(t *testing.T) {
 		partyBAddr = partyAAddr
 	}
 
-	client := facade.NewClient(protocol, trpClient).
-		WithProfile("preprod").
+	client, err := e2eBuilder(t, endpoint).
 		WithParty("sender", facade.SignerParty(cardanoSigner)).
 		WithParty("receiver", facade.AddressParty(partyBAddr)).
-		WithParty("middleman", facade.AddressParty(partyBAddr))
+		WithParty("middleman", facade.AddressParty(partyBAddr)).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
 
-	resolved, err := client.Tx("transfer").
-		Arg("quantity", 10_000_000).
-		Resolve(ctx)
+	txb, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+
+	resolved, err := txb.Arg("quantity", 10_000_000).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -115,15 +124,21 @@ func TestE2EBadEndpoint(t *testing.T) {
 		t.Fatalf("FromFile failed: %v", err)
 	}
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: "http://localhost:1"})
-	client := facade.NewClient(protocol, trpClient).
+	client, err := facade.FromProtocol(protocol).
+		TRPEndpoint("http://localhost:1").
 		WithParty("sender", facade.AddressParty("addr_test1...")).
 		WithParty("receiver", facade.AddressParty("addr_test1...")).
-		WithParty("middleman", facade.AddressParty("addr_test1..."))
+		WithParty("middleman", facade.AddressParty("addr_test1...")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
-	_, err = client.Tx("transfer").
-		Arg("quantity", 100).
-		Resolve(context.Background())
+	txb, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	_, err = txb.Arg("quantity", 100).Resolve(context.Background())
 	if err == nil {
 		t.Fatal("expected error for bad endpoint")
 	}
@@ -135,25 +150,26 @@ func TestE2EPollTimeout(t *testing.T) {
 	partyAAddr := requireEnv(t, "TEST_PARTY_A_ADDRESS")
 	partyAMnemonic := requireEnv(t, "TEST_PARTY_A_MNEMONIC")
 
-	protocol, err := tii.FromFile("../testdata/transfer.tii")
-	if err != nil {
-		t.Fatalf("FromFile failed: %v", err)
-	}
-
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: endpoint, Headers: trpHeadersFromEnv()})
 	cardanoSigner, err := signer.CardanoSignerFromMnemonic(partyAAddr, partyAMnemonic)
 	if err != nil {
 		t.Fatalf("CardanoSignerFromMnemonic failed: %v", err)
 	}
 
-	client := facade.NewClient(protocol, trpClient).
-		WithProfile("preprod").
+	client, err := e2eBuilder(t, endpoint).
 		WithParty("sender", facade.SignerParty(cardanoSigner)).
 		WithParty("receiver", facade.AddressParty(partyAAddr)).
-		WithParty("middleman", facade.AddressParty(partyAAddr))
+		WithParty("middleman", facade.AddressParty(partyAAddr)).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
-	resolved, err := client.Tx("transfer").Arg("quantity", 10_000_000).Resolve(ctx)
+	txb, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	resolved, err := txb.Arg("quantity", 10_000_000).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}

--- a/sdk/facade/add_witness_test.go
+++ b/sdk/facade/add_witness_test.go
@@ -56,17 +56,25 @@ func recordingTRPServer(t *testing.T) (*httptest.Server, *trp.Client, *trp.Submi
 }
 
 func TestResolvedTx_AddWitness_OnlyNoSigners(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient, captured := recordingTRPServer(t)
+	server, _, captured := recordingTRPServer(t)
 	defer server.Close()
 
-	client := facade.NewClient(protocol, trpClient).
+	client, err := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.AddressParty("addr_sender")).
 		WithParty("receiver", facade.AddressParty("addr_receiver")).
-		WithParty("middleman", facade.AddressParty("addr_middleman"))
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
-	resolved, err := client.Tx("transfer").Arg("quantity", 100).Resolve(ctx)
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	resolved, err := b.Arg("quantity", 100).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -89,18 +97,26 @@ func TestResolvedTx_AddWitness_OnlyNoSigners(t *testing.T) {
 }
 
 func TestResolvedTx_AddWitness_MixedWithRegisteredSigner(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient, captured := recordingTRPServer(t)
+	server, _, captured := recordingTRPServer(t)
 	defer server.Close()
 
 	mock := &mockSigner{address: "addr_sender", pubKey: "11", sig: "22"}
-	client := facade.NewClient(protocol, trpClient).
+	client, err := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.SignerParty(mock)).
 		WithParty("receiver", facade.AddressParty("addr_receiver")).
-		WithParty("middleman", facade.AddressParty("addr_middleman"))
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
-	resolved, err := client.Tx("transfer").Arg("quantity", 100).Resolve(ctx)
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	resolved, err := b.Arg("quantity", 100).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -125,17 +141,25 @@ func TestResolvedTx_AddWitness_MixedWithRegisteredSigner(t *testing.T) {
 }
 
 func TestResolvedTx_AddWitness_PreservesOrder(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient, captured := recordingTRPServer(t)
+	server, _, captured := recordingTRPServer(t)
 	defer server.Close()
 
-	client := facade.NewClient(protocol, trpClient).
+	client, err := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.AddressParty("addr_sender")).
 		WithParty("receiver", facade.AddressParty("addr_receiver")).
-		WithParty("middleman", facade.AddressParty("addr_middleman"))
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
-	resolved, err := client.Tx("transfer").Arg("quantity", 100).Resolve(ctx)
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	resolved, err := b.Arg("quantity", 100).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}

--- a/sdk/facade/builder.go
+++ b/sdk/facade/builder.go
@@ -6,26 +6,58 @@ import (
 
 	"github.com/tx3-lang/go-sdk/sdk/core"
 	"github.com/tx3-lang/go-sdk/sdk/signer"
-	"github.com/tx3-lang/go-sdk/sdk/tii"
 	"github.com/tx3-lang/go-sdk/sdk/trp"
 )
 
 // TxBuilder collects transaction arguments and resolves the transaction via TRP.
+//
+// Source-agnostic: holds the TIR envelope directly, plus the environment
+// values from the selected profile (with builder-supplied overrides already
+// folded in), the bound parties, and the typed args. Drives a single Resolve()
+// path regardless of whether the upstream was a runtime-loaded *tii.Protocol
+// or codegen-embedded fragments.
 type TxBuilder struct {
-	protocol *tii.Protocol
-	trp      *trp.Client
-	txName   string
-	args     map[string]interface{}
-	parties  map[string]Party
-	profile  *string
+	tir     core.TirEnvelope
+	trp     *trp.Client
+	env     core.EnvMap
+	parties map[string]Party
+	args    map[string]interface{}
 }
 
-// Arg sets a single transaction argument. The key is matched case-insensitively
-// against protocol-declared parameter names.
+// newTxBuilder is the internal constructor used by Tx3Client.Tx().
+func newTxBuilder(trpClient *trp.Client, tir core.TirEnvelope) *TxBuilder {
+	return &TxBuilder{
+		tir:     tir,
+		trp:     trpClient,
+		env:     core.EnvMap{},
+		parties: make(map[string]Party),
+		args:    make(map[string]interface{}),
+	}
+}
+
+// Env sets the environment values applied to this transaction.
+func (b *TxBuilder) Env(env core.EnvMap) *TxBuilder {
+	b.env = core.EnvMap{}
+	for k, v := range env {
+		b.env[k] = v
+	}
+	return b
+}
+
+// Parties attaches party definitions (case-insensitive names).
+func (b *TxBuilder) Parties(parties map[string]Party) *TxBuilder {
+	for name, party := range parties {
+		b.parties[strings.ToLower(name)] = party
+	}
+	return b
+}
+
+// Arg sets a single transaction argument. The key is matched case-
+// insensitively against protocol-declared parameter names.
 func (b *TxBuilder) Arg(name string, value interface{}) *TxBuilder {
 	coerced, err := core.CoerceArg(value)
 	if err != nil {
-		// Store raw value; validation happens at resolve time
+		// Store raw value; validation happens server-side.
 		b.args[core.NormalizeArgKey(name)] = value
 	} else {
 		b.args[core.NormalizeArgKey(name)] = coerced
@@ -50,57 +82,32 @@ type signerParty struct {
 // Resolve invokes the TRP server to resolve this transaction.
 // Returns a ResolvedTx ready for signing.
 func (b *TxBuilder) Resolve(ctx context.Context) (*ResolvedTx, error) {
-	// Create invocation from protocol
-	inv, err := b.protocol.Invoke(b.txName, b.profile)
-	if err != nil {
-		return nil, err
+	merged := map[string]interface{}{}
+	for k, v := range b.env {
+		merged[k] = v
 	}
-
-	// Validate parties and inject their addresses
-	protocolParties := b.protocol.Parties()
-	var signers []signerParty
 	for name, party := range b.parties {
-		// Check that the party is known to the protocol
-		found := false
-		for pName := range protocolParties {
-			if strings.EqualFold(pName, name) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, &UnknownPartyError{Name: name}
-		}
-
-		// Inject party address as an argument
-		inv.SetArg(name, party.partyAddress())
-
-		// Collect signers
-		if party.isSigner {
-			signers = append(signers, signerParty{name: name, signer: party.signer})
-		}
+		merged[name] = party.partyAddress()
 	}
-
-	// Set user-provided args (these override party-injected ones)
 	for k, v := range b.args {
-		inv.SetArg(k, v)
+		merged[k] = v
 	}
 
-	// Convert to resolve request
-	tirEnvelope, args, err := inv.IntoResolveRequest()
-	if err != nil {
-		return nil, err
-	}
-
-	// Call TRP resolve
 	resolveParams := trp.ResolveParams{
-		Tir:  tirEnvelope,
-		Args: args,
+		Tir:  b.tir,
+		Args: merged,
 	}
 
 	envelope, err := b.trp.Resolve(ctx, resolveParams)
 	if err != nil {
 		return nil, err
+	}
+
+	var signers []signerParty
+	for name, party := range b.parties {
+		if party.isSigner {
+			signers = append(signers, signerParty{name: name, signer: party.signer})
+		}
 	}
 
 	return &ResolvedTx{

--- a/sdk/facade/client.go
+++ b/sdk/facade/client.go
@@ -4,78 +4,134 @@
 package facade
 
 import (
+	"strings"
+
+	"github.com/tx3-lang/go-sdk/sdk/core"
 	"github.com/tx3-lang/go-sdk/sdk/tii"
 	"github.com/tx3-lang/go-sdk/sdk/trp"
 )
 
 // Tx3Client is the main entry point for the Tx3 SDK.
-// It holds a loaded protocol, a TRP client, and party bindings,
-// and creates TxBuilder instances for building transactions.
+//
+// Holds the deconstructed protocol parts — per-transaction TIR envelopes, the
+// set of declared party names, the selected profile — plus the runtime state
+// (TRP client, bound parties, env overrides). Built through Tx3ClientBuilder
+// (obtained via Protocol.Client() or facade.FromParts). Profile selection is
+// locked in at build time: there is no profile-switching method on the built
+// client.
 type Tx3Client struct {
-	protocol *tii.Protocol
-	trp      *trp.Client
-	parties  map[string]Party
-	profile  *string
+	transactions    map[string]core.TirEnvelope
+	knownParties    map[string]bool
+	trp             *trp.Client
+	boundParties    map[string]Party
+	selectedProfile *Profile
+	envOverrides    core.EnvMap
 }
 
-// NewClient creates a new Tx3Client with the given protocol and TRP client.
-func NewClient(protocol *tii.Protocol, trpClient *trp.Client) *Tx3Client {
+// newClient is the internal constructor used by Tx3ClientBuilder.Build().
+func newClient(
+	transactions map[string]core.TirEnvelope,
+	knownParties map[string]bool,
+	trpClient *trp.Client,
+	boundParties map[string]Party,
+	selectedProfile *Profile,
+	envOverrides core.EnvMap,
+) *Tx3Client {
 	return &Tx3Client{
-		protocol: protocol,
-		trp:      trpClient,
-		parties:  make(map[string]Party),
+		transactions:    transactions,
+		knownParties:    knownParties,
+		trp:             trpClient,
+		boundParties:    boundParties,
+		selectedProfile: selectedProfile,
+		envOverrides:    envOverrides,
 	}
 }
 
-// WithProfile returns a new Tx3Client with the given profile set.
-// The profile is applied to every invocation created by this client.
-func (c *Tx3Client) WithProfile(name string) *Tx3Client {
-	cp := c.clone()
-	cp.profile = &name
-	return cp
-}
-
-// WithParty returns a new Tx3Client with the named party attached.
-func (c *Tx3Client) WithParty(name string, party Party) *Tx3Client {
-	cp := c.clone()
-	cp.parties[name] = party
-	return cp
-}
-
-// WithParties returns a new Tx3Client with multiple parties attached.
-func (c *Tx3Client) WithParties(parties map[string]Party) *Tx3Client {
-	cp := c.clone()
-	for k, v := range parties {
-		cp.parties[k] = v
+// WithParty returns a new Tx3Client with the named party bound. Validated
+// against the protocol's declared parties.
+//
+// Returns *UnknownPartyError if name is not declared by the protocol.
+func (c *Tx3Client) WithParty(name string, party Party) (*Tx3Client, error) {
+	lower := strings.ToLower(name)
+	if !c.knownParties[lower] {
+		return nil, &UnknownPartyError{Name: lower}
 	}
-	return cp
+	next := c.cloneParties()
+	next[lower] = party
+	return c.withBoundParties(next), nil
 }
 
-// Tx begins building a transaction by name, returning a TxBuilder.
-func (c *Tx3Client) Tx(name string) *TxBuilder {
-	return &TxBuilder{
-		protocol: c.protocol,
-		trp:      c.trp,
-		txName:   name,
-		args:     make(map[string]interface{}),
-		parties:  c.cloneParties(),
-		profile:  c.profile,
-	}
+// WithPartyUnchecked returns a new Tx3Client with the named party bound,
+// skipping the declared-party lookup. Intended for codegen-generated
+// wrappers; hand-written code SHOULD prefer WithParty.
+func (c *Tx3Client) WithPartyUnchecked(name string, party Party) *Tx3Client {
+	next := c.cloneParties()
+	next[strings.ToLower(name)] = party
+	return c.withBoundParties(next)
 }
 
-func (c *Tx3Client) clone() *Tx3Client {
-	return &Tx3Client{
-		protocol: c.protocol,
-		trp:      c.trp,
-		parties:  c.cloneParties(),
-		profile:  c.profile,
+// WithParties returns a new Tx3Client with multiple parties bound at once.
+// See WithParty.
+func (c *Tx3Client) WithParties(parties map[string]Party) (*Tx3Client, error) {
+	next := c.cloneParties()
+	for name, party := range parties {
+		lower := strings.ToLower(name)
+		if !c.knownParties[lower] {
+			return nil, &UnknownPartyError{Name: lower}
+		}
+		next[lower] = party
 	}
+	return c.withBoundParties(next), nil
+}
+
+// Tx starts building a transaction invocation.
+//
+// Returns *tii.UnknownTxError if name is not a transaction declared by the
+// protocol.
+func (c *Tx3Client) Tx(name string) (*TxBuilder, error) {
+	tirEnvelope, ok := c.transactions[name]
+	if !ok {
+		return nil, &tii.UnknownTxError{Name: name}
+	}
+	env := c.mergedEnv()
+	parties := c.mergedParties()
+	return newTxBuilder(c.trp, tirEnvelope).Env(env).Parties(parties), nil
+}
+
+func (c *Tx3Client) withBoundParties(next map[string]Party) *Tx3Client {
+	return newClient(c.transactions, c.knownParties, c.trp, next, c.selectedProfile, c.envOverrides)
 }
 
 func (c *Tx3Client) cloneParties() map[string]Party {
-	cp := make(map[string]Party, len(c.parties))
-	for k, v := range c.parties {
+	cp := make(map[string]Party, len(c.boundParties))
+	for k, v := range c.boundParties {
 		cp[k] = v
 	}
 	return cp
+}
+
+func (c *Tx3Client) mergedEnv() core.EnvMap {
+	env := core.EnvMap{}
+	if c.selectedProfile != nil {
+		for k, v := range c.selectedProfile.Environment {
+			env[k] = v
+		}
+	}
+	for k, v := range c.envOverrides {
+		env[k] = v
+	}
+	return env
+}
+
+func (c *Tx3Client) mergedParties() map[string]Party {
+	merged := make(map[string]Party)
+	if c.selectedProfile != nil {
+		for name, address := range c.selectedProfile.Parties {
+			merged[strings.ToLower(name)] = AddressParty(address)
+		}
+	}
+	for name, party := range c.boundParties {
+		merged[name] = party
+	}
+	return merged
 }

--- a/sdk/facade/client_builder.go
+++ b/sdk/facade/client_builder.go
@@ -1,0 +1,211 @@
+package facade
+
+import (
+	"strings"
+
+	"github.com/tx3-lang/go-sdk/sdk/core"
+	"github.com/tx3-lang/go-sdk/sdk/tii"
+	"github.com/tx3-lang/go-sdk/sdk/trp"
+)
+
+// Tx3ClientBuilder builds a Tx3Client.
+//
+// Obtained via Protocol.Client() for the dynamic flow or FromParts for the
+// codegen flow. All fallible validation — TRP endpoint present, selected
+// profile declared, every bound party declared — happens in Build(). Optional
+// setters never fail, so chains stay fluent.
+//
+// Example:
+//
+//	client, err := protocol.Client().
+//	    TRPEndpoint("https://trp.example").
+//	    WithProfile("preprod").
+//	    WithParty("sender", facade.SignerParty(signer)).
+//	    Build()
+type Tx3ClientBuilder struct {
+	transactions      map[string]core.TirEnvelope
+	profiles          map[string]Profile
+	knownParties      map[string]bool
+	trpOptions        *trp.ClientOptions
+	trpClientOverride *trp.Client
+	profile           *string
+	parties           map[string]Party
+	uncheckedParties  map[string]Party
+	envOverrides      core.EnvMap
+}
+
+// NewBuilder creates an empty Tx3ClientBuilder seeded with the supplied parts.
+// Prefer Protocol.Client() or FromParts.
+func newBuilder(
+	transactions map[string]core.TirEnvelope,
+	profiles map[string]Profile,
+	knownParties map[string]bool,
+) *Tx3ClientBuilder {
+	return &Tx3ClientBuilder{
+		transactions:     transactions,
+		profiles:         profiles,
+		knownParties:     knownParties,
+		parties:          make(map[string]Party),
+		uncheckedParties: make(map[string]Party),
+		envOverrides:     core.EnvMap{},
+	}
+}
+
+// FromParts seeds a builder with already-deconstructed protocol fragments.
+//
+// Codegen-generated bindings call this with embedded per-transaction TIR
+// envelopes, per-profile environment + party-address maps, and (typically)
+// an empty known-parties set — the typed With<Party> wrapper methods bake
+// party names in at codegen time so runtime name validation is unnecessary.
+func FromParts(
+	transactions map[string]core.TirEnvelope,
+	profiles map[string]Profile,
+	knownParties []string,
+) *Tx3ClientBuilder {
+	knownSet := make(map[string]bool, len(knownParties))
+	for _, name := range knownParties {
+		knownSet[strings.ToLower(name)] = true
+	}
+	return newBuilder(transactions, profiles, knownSet)
+}
+
+// FromProtocol seeds a builder from a runtime-loaded protocol. Entry point for
+// Protocol.Client().
+func FromProtocol(p *tii.Protocol) *Tx3ClientBuilder {
+	transactions := make(map[string]core.TirEnvelope)
+	for name, tx := range p.Transactions() {
+		transactions[name] = tx.Tir
+	}
+
+	profiles := make(map[string]Profile)
+	for name, spec := range p.Profiles() {
+		parties := make(map[string]string, len(spec.Parties))
+		for k, v := range spec.Parties {
+			parties[k] = v
+		}
+		env := core.EnvMap{}
+		for k, v := range spec.Environment {
+			env[k] = v
+		}
+		profiles[name] = Profile{Environment: env, Parties: parties}
+	}
+
+	known := make(map[string]bool)
+	for name := range p.Parties() {
+		known[strings.ToLower(name)] = true
+	}
+
+	return newBuilder(transactions, profiles, known)
+}
+
+// TRP sets the full TRP client options.
+func (b *Tx3ClientBuilder) TRP(options trp.ClientOptions) *Tx3ClientBuilder {
+	b.trpOptions = &options
+	return b
+}
+
+// TRPEndpoint is a shorthand for TRP(trp.ClientOptions{Endpoint: url}).
+func (b *Tx3ClientBuilder) TRPEndpoint(url string) *Tx3ClientBuilder {
+	b.trpOptions = &trp.ClientOptions{Endpoint: url}
+	return b
+}
+
+// WithHeader adds a single TRP request header. Initializes options to an empty
+// endpoint if not set — callers must still supply the endpoint via TRP() or
+// TRPEndpoint().
+func (b *Tx3ClientBuilder) WithHeader(key, value string) *Tx3ClientBuilder {
+	if b.trpOptions == nil {
+		b.trpOptions = &trp.ClientOptions{}
+	}
+	if b.trpOptions.Headers == nil {
+		b.trpOptions.Headers = map[string]string{}
+	}
+	b.trpOptions.Headers[key] = value
+	return b
+}
+
+// WithProfile selects a profile by name. Validated in Build().
+func (b *Tx3ClientBuilder) WithProfile(name string) *Tx3ClientBuilder {
+	b.profile = &name
+	return b
+}
+
+// WithParty binds a party by name. The name is validated against the
+// protocol's declared parties in Build().
+func (b *Tx3ClientBuilder) WithParty(name string, party Party) *Tx3ClientBuilder {
+	b.parties[strings.ToLower(name)] = party
+	return b
+}
+
+// WithPartyUnchecked binds a party without validating the name against the
+// protocol's declared parties. Intended for codegen-generated wrappers; hand-
+// written code SHOULD prefer WithParty.
+func (b *Tx3ClientBuilder) WithPartyUnchecked(name string, party Party) *Tx3ClientBuilder {
+	b.uncheckedParties[strings.ToLower(name)] = party
+	return b
+}
+
+// WithParties binds multiple parties at once. See WithParty.
+func (b *Tx3ClientBuilder) WithParties(parties map[string]Party) *Tx3ClientBuilder {
+	for name, party := range parties {
+		b.WithParty(name, party)
+	}
+	return b
+}
+
+// WithEnvValue sets a single environment value, merged on top of the selected
+// profile's environment at resolve time (override wins).
+func (b *Tx3ClientBuilder) WithEnvValue(key string, value interface{}) *Tx3ClientBuilder {
+	b.envOverrides[key] = value
+	return b
+}
+
+// trpClient is an internal escape hatch that lets tests inject a pre-built /
+// fake TRP client without going through the ClientOptions construction path.
+// Not part of the public API.
+func (b *Tx3ClientBuilder) trpClient(client *trp.Client) *Tx3ClientBuilder {
+	b.trpClientOverride = client
+	return b
+}
+
+// Build validates the builder state and materializes the Tx3Client.
+//
+// Returns *MissingTrpEndpointError if no TRP endpoint was supplied,
+// *tii.UnknownProfileError if the selected profile is not declared, and
+// *UnknownPartyError if any bound party is not declared.
+func (b *Tx3ClientBuilder) Build() (*Tx3Client, error) {
+	var trpClient *trp.Client
+	if b.trpClientOverride != nil {
+		trpClient = b.trpClientOverride
+	} else {
+		if b.trpOptions == nil || b.trpOptions.Endpoint == "" {
+			return nil, &MissingTrpEndpointError{}
+		}
+		trpClient = trp.NewClient(*b.trpOptions)
+	}
+
+	var selectedProfile *Profile
+	if b.profile != nil {
+		profile, ok := b.profiles[*b.profile]
+		if !ok {
+			return nil, &tii.UnknownProfileError{Name: *b.profile}
+		}
+		selectedProfile = &profile
+	}
+
+	for name := range b.parties {
+		if !b.knownParties[name] {
+			return nil, &UnknownPartyError{Name: name}
+		}
+	}
+
+	bound := make(map[string]Party, len(b.parties)+len(b.uncheckedParties))
+	for name, party := range b.parties {
+		bound[name] = party
+	}
+	for name, party := range b.uncheckedParties {
+		bound[name] = party
+	}
+
+	return newClient(b.transactions, b.knownParties, trpClient, bound, selectedProfile, b.envOverrides), nil
+}

--- a/sdk/facade/client_test.go
+++ b/sdk/facade/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/tx3-lang/go-sdk/sdk/core"
 	"github.com/tx3-lang/go-sdk/sdk/facade"
 	"github.com/tx3-lang/go-sdk/sdk/signer"
 	"github.com/tx3-lang/go-sdk/sdk/tii"
@@ -69,52 +70,146 @@ func newMockTRPServer(t *testing.T) (*httptest.Server, *trp.Client) {
 	return server, client
 }
 
-func TestBuilderUnknownTransaction(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient := newMockTRPServer(t)
+func newBuilder(t *testing.T, server *httptest.Server) *facade.Tx3ClientBuilder {
+	t.Helper()
+	return facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
+		WithProfile("preprod")
+}
+
+func TestBuilder_MissingEndpoint(t *testing.T) {
+	_, err := facade.FromProtocol(newTestProtocol(t)).Build()
+	if err == nil {
+		t.Fatal("expected MissingTrpEndpointError")
+	}
+	var missing *facade.MissingTrpEndpointError
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected *MissingTrpEndpointError, got %T: %v", err, err)
+	}
+}
+
+func TestBuilder_UnknownProfile(t *testing.T) {
+	server, _ := newMockTRPServer(t)
 	defer server.Close()
 
-	client := facade.NewClient(protocol, trpClient)
-	_, err := client.Tx("nonexistent").
-		Arg("quantity", 100).
-		Resolve(context.Background())
+	_, err := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
+		WithProfile("not-a-profile").
+		Build()
+	if err == nil {
+		t.Fatal("expected UnknownProfileError")
+	}
+	var profErr *tii.UnknownProfileError
+	if !errors.As(err, &profErr) {
+		t.Fatalf("expected *tii.UnknownProfileError, got %T: %v", err, err)
+	}
+}
 
+func TestBuilder_UnknownParty(t *testing.T) {
+	server, _ := newMockTRPServer(t)
+	defer server.Close()
+
+	_, err := newBuilder(t, server).
+		WithParty("stranger", facade.AddressParty("addr_stranger")).
+		Build()
+	if err == nil {
+		t.Fatal("expected UnknownPartyError")
+	}
+	var partyErr *facade.UnknownPartyError
+	if !errors.As(err, &partyErr) {
+		t.Fatalf("expected *facade.UnknownPartyError, got %T: %v", err, err)
+	}
+}
+
+func TestBuilder_WithPartyUncheckedBypassesValidation(t *testing.T) {
+	server, _ := newMockTRPServer(t)
+	defer server.Close()
+
+	_, err := newBuilder(t, server).
+		WithPartyUnchecked("stranger", facade.AddressParty("addr_stranger")).
+		Build()
+	if err != nil {
+		t.Fatalf("WithPartyUnchecked should not validate, got error: %v", err)
+	}
+}
+
+func TestTx_UnknownTransaction(t *testing.T) {
+	server, _ := newMockTRPServer(t)
+	defer server.Close()
+
+	client, err := newBuilder(t, server).
+		WithParty("sender", facade.AddressParty("addr_sender")).
+		WithParty("receiver", facade.AddressParty("addr_receiver")).
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	_, err = client.Tx("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown transaction")
 	}
 	var txErr *tii.UnknownTxError
 	if !errors.As(err, &txErr) {
-		t.Fatalf("expected UnknownTxError, got %T: %v", err, err)
+		t.Fatalf("expected *tii.UnknownTxError, got %T: %v", err, err)
 	}
 }
 
-func TestBuilderUnknownParty(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient := newMockTRPServer(t)
+func TestBuiltClient_WithParty_RejectsUnknown(t *testing.T) {
+	server, _ := newMockTRPServer(t)
 	defer server.Close()
 
-	client := facade.NewClient(protocol, trpClient).
-		WithParty("unknown_party", facade.AddressParty("addr_test1..."))
-
-	_, err := client.Tx("transfer").
-		Arg("quantity", 100).
-		Resolve(context.Background())
-
+	client, _ := newBuilder(t, server).Build()
+	_, err := client.WithParty("ghost", facade.AddressParty("addr_ghost"))
 	if err == nil {
-		t.Fatal("expected error for unknown party")
+		t.Fatal("expected UnknownPartyError on late-binding")
 	}
 	var partyErr *facade.UnknownPartyError
 	if !errors.As(err, &partyErr) {
-		t.Fatalf("expected UnknownPartyError, got %T: %v", err, err)
+		t.Fatalf("expected *facade.UnknownPartyError, got %T: %v", err, err)
 	}
-	if partyErr.Name != "unknown_party" {
-		t.Errorf("expected party name 'unknown_party', got %q", partyErr.Name)
+}
+
+func TestBuilder_WithEnvValue_OverridesProfileEnv(t *testing.T) {
+	var receivedArgs map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]json.RawMessage
+		json.NewDecoder(r.Body).Decode(&req)
+		var params map[string]json.RawMessage
+		json.Unmarshal(req["params"], &params)
+		json.Unmarshal(params["args"], &receivedArgs)
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": "1",
+			"result": map[string]interface{}{"hash": "abc", "tx": "def"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := newBuilder(t, server).
+		WithPartyUnchecked("sender", facade.AddressParty("addr_sender")).
+		WithPartyUnchecked("receiver", facade.AddressParty("addr_receiver")).
+		WithPartyUnchecked("middleman", facade.AddressParty("addr_middleman")).
+		WithEnvValue("tax", float64(999)).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	_, err = b.Arg("quantity", 100).Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if got, ok := receivedArgs["tax"].(float64); !ok || got != 999 {
+		t.Errorf("expected env override tax=999, got %v", receivedArgs["tax"])
 	}
 }
 
 func TestPartyAddressInjection(t *testing.T) {
-	protocol := newTestProtocol(t)
-
 	var receivedArgs map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]json.RawMessage
@@ -131,19 +226,24 @@ func TestPartyAddressInjection(t *testing.T) {
 	}))
 	defer server.Close()
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: server.URL})
-	client := facade.NewClient(protocol, trpClient).
+	client, err := newBuilder(t, server).
 		WithParty("sender", facade.AddressParty("addr_sender_123")).
-		WithParty("receiver", facade.AddressParty("addr_receiver_456"))
+		WithParty("receiver", facade.AddressParty("addr_receiver_456")).
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
-	_, err := client.Tx("transfer").
-		Arg("quantity", 100).
-		Resolve(context.Background())
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	_, err = b.Arg("quantity", 100).Resolve(context.Background())
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 
-	// Verify party addresses were injected into args
 	if receivedArgs["sender"] != "addr_sender_123" {
 		t.Errorf("expected sender address 'addr_sender_123', got %v", receivedArgs["sender"])
 	}
@@ -153,8 +253,7 @@ func TestPartyAddressInjection(t *testing.T) {
 }
 
 func TestFullBuilderChainWithMockSigner(t *testing.T) {
-	protocol := newTestProtocol(t)
-	server, trpClient := newMockTRPServer(t)
+	server, _ := newMockTRPServer(t)
 	defer server.Close()
 
 	mock := &mockSigner{
@@ -163,18 +262,22 @@ func TestFullBuilderChainWithMockSigner(t *testing.T) {
 		sig:     "11223344",
 	}
 
-	client := facade.NewClient(protocol, trpClient).
-		WithProfile("preprod").
+	client, err := newBuilder(t, server).
 		WithParty("sender", facade.SignerParty(mock)).
 		WithParty("receiver", facade.AddressParty("addr_receiver")).
-		WithParty("middleman", facade.AddressParty("addr_middleman"))
+		WithParty("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
 	ctx := context.Background()
 
-	// Resolve
-	resolved, err := client.Tx("transfer").
-		Arg("quantity", 10_000_000).
-		Resolve(ctx)
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	resolved, err := b.Arg("quantity", 10_000_000).Resolve(ctx)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
@@ -185,7 +288,6 @@ func TestFullBuilderChainWithMockSigner(t *testing.T) {
 		t.Error("expected non-empty TxHex")
 	}
 
-	// Sign
 	signed, err := resolved.Sign()
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
@@ -194,7 +296,6 @@ func TestFullBuilderChainWithMockSigner(t *testing.T) {
 		t.Errorf("expected 1 witness, got %d", len(signed.Witnesses()))
 	}
 
-	// Submit
 	submitted, err := signed.Submit(ctx)
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
@@ -203,7 +304,6 @@ func TestFullBuilderChainWithMockSigner(t *testing.T) {
 		t.Error("expected non-empty submitted hash")
 	}
 
-	// WaitForConfirmed
 	status, err := submitted.WaitForConfirmed(ctx, facade.DefaultPollConfig())
 	if err != nil {
 		t.Fatalf("WaitForConfirmed failed: %v", err)
@@ -213,10 +313,51 @@ func TestFullBuilderChainWithMockSigner(t *testing.T) {
 	}
 }
 
-func TestSubmitHashMismatch(t *testing.T) {
-	protocol := newTestProtocol(t)
+func TestFromParts_CodegenFlow(t *testing.T) {
+	var receivedArgs map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]json.RawMessage
+		json.NewDecoder(r.Body).Decode(&req)
+		var params map[string]json.RawMessage
+		json.Unmarshal(req["params"], &params)
+		json.Unmarshal(params["args"], &receivedArgs)
 
-	// Server returns a different hash on submit
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": "1",
+			"result": map[string]interface{}{"hash": "abc", "tx": "def"},
+		})
+	}))
+	defer server.Close()
+
+	protocol := newTestProtocol(t)
+	transactions := map[string]core.TirEnvelope{}
+	for name, tx := range protocol.Transactions() {
+		transactions[name] = tx.Tir
+	}
+
+	client, err := facade.FromParts(transactions, nil, nil).
+		TRPEndpoint(server.URL).
+		WithPartyUnchecked("sender", facade.AddressParty("addr_sender_codegen")).
+		WithPartyUnchecked("receiver", facade.AddressParty("addr_receiver_codegen")).
+		WithPartyUnchecked("middleman", facade.AddressParty("addr_middleman")).
+		Build()
+	if err != nil {
+		t.Fatalf("FromParts build failed: %v", err)
+	}
+
+	b, err := client.Tx("transfer")
+	if err != nil {
+		t.Fatalf("Tx failed: %v", err)
+	}
+	if _, err := b.Arg("quantity", 1).Resolve(context.Background()); err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if receivedArgs["sender"] != "addr_sender_codegen" {
+		t.Errorf("expected sender injected via FromParts/WithPartyUnchecked, got %v", receivedArgs["sender"])
+	}
+}
+
+func TestSubmitHashMismatch(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]json.RawMessage
 		json.NewDecoder(r.Body).Decode(&req)
@@ -243,16 +384,21 @@ func TestSubmitHashMismatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: server.URL})
 	mock := &mockSigner{address: "addr", pubKey: "aa", sig: "bb"}
-	client := facade.NewClient(protocol, trpClient).
+	client, err := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.SignerParty(mock)).
 		WithParty("receiver", facade.AddressParty("addr_r")).
-		WithParty("middleman", facade.AddressParty("addr_m"))
+		WithParty("middleman", facade.AddressParty("addr_m")).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
 
-	resolved, _ := client.Tx("transfer").Arg("quantity", 100).Resolve(context.Background())
+	b, _ := client.Tx("transfer")
+	resolved, _ := b.Arg("quantity", 100).Resolve(context.Background())
 	signed, _ := resolved.Sign()
-	_, err := signed.Submit(context.Background())
+	_, err = signed.Submit(context.Background())
 
 	if err == nil {
 		t.Fatal("expected SubmitHashMismatchError")
@@ -264,8 +410,6 @@ func TestSubmitHashMismatch(t *testing.T) {
 }
 
 func TestWaitForConfirmedTimeout(t *testing.T) {
-	protocol := newTestProtocol(t)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]json.RawMessage
 		json.NewDecoder(r.Body).Decode(&req)
@@ -303,15 +447,17 @@ func TestWaitForConfirmedTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: server.URL})
 	mock := &mockSigner{address: "addr", pubKey: "aa", sig: "bb"}
-	client := facade.NewClient(protocol, trpClient).
+	client, _ := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.SignerParty(mock)).
 		WithParty("receiver", facade.AddressParty("addr_r")).
-		WithParty("middleman", facade.AddressParty("addr_m"))
+		WithParty("middleman", facade.AddressParty("addr_m")).
+		Build()
 
 	ctx := context.Background()
-	resolved, _ := client.Tx("transfer").Arg("quantity", 100).Resolve(ctx)
+	b, _ := client.Tx("transfer")
+	resolved, _ := b.Arg("quantity", 100).Resolve(ctx)
 	signed, _ := resolved.Sign()
 	submitted, _ := signed.Submit(ctx)
 
@@ -326,8 +472,6 @@ func TestWaitForConfirmedTimeout(t *testing.T) {
 }
 
 func TestWaitForConfirmedDropped(t *testing.T) {
-	protocol := newTestProtocol(t)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]json.RawMessage
 		json.NewDecoder(r.Body).Decode(&req)
@@ -362,15 +506,17 @@ func TestWaitForConfirmedDropped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	trpClient := trp.NewClient(trp.ClientOptions{Endpoint: server.URL})
 	mock := &mockSigner{address: "addr", pubKey: "aa", sig: "bb"}
-	client := facade.NewClient(protocol, trpClient).
+	client, _ := facade.FromProtocol(newTestProtocol(t)).
+		TRPEndpoint(server.URL).
 		WithParty("sender", facade.SignerParty(mock)).
 		WithParty("receiver", facade.AddressParty("addr_r")).
-		WithParty("middleman", facade.AddressParty("addr_m"))
+		WithParty("middleman", facade.AddressParty("addr_m")).
+		Build()
 
 	ctx := context.Background()
-	resolved, _ := client.Tx("transfer").Arg("quantity", 100).Resolve(ctx)
+	b, _ := client.Tx("transfer")
+	resolved, _ := b.Arg("quantity", 100).Resolve(ctx)
 	signed, _ := resolved.Sign()
 	submitted, _ := signed.Submit(ctx)
 

--- a/sdk/facade/errors.go
+++ b/sdk/facade/errors.go
@@ -21,6 +21,14 @@ func (e *UnknownPartyError) Error() string {
 }
 func (e *UnknownPartyError) isFacadeError() {}
 
+// MissingTrpEndpointError indicates Build() ran without a TRP endpoint.
+type MissingTrpEndpointError struct{}
+
+func (e *MissingTrpEndpointError) Error() string {
+	return "TRP endpoint not configured"
+}
+func (e *MissingTrpEndpointError) isFacadeError() {}
+
 // MissingParamsError indicates required parameters were not provided.
 type MissingParamsError struct {
 	Params []string

--- a/sdk/facade/profile.go
+++ b/sdk/facade/profile.go
@@ -1,0 +1,14 @@
+package facade
+
+import "github.com/tx3-lang/go-sdk/sdk/core"
+
+// Profile is a named profile baked into a client: environment values and
+// party-address overrides keyed by name.
+//
+// Produced either by deconstructing a loaded *tii.Protocol inside
+// Tx3ClientBuilder.FromProtocol, or by feeding the per-profile JSON blob a
+// generated codegen client embeds through Tx3ClientBuilder.FromParts.
+type Profile struct {
+	Environment core.EnvMap
+	Parties     map[string]string
+}

--- a/sdk/tii/protocol.go
+++ b/sdk/tii/protocol.go
@@ -61,6 +61,11 @@ func (p *Protocol) TiiVersion() string {
 	return p.spec.Tii.Version
 }
 
+// Environment returns the protocol-level environment schema, if declared.
+func (p *Protocol) Environment() *Schema {
+	return p.spec.Environment
+}
+
 // Invoke creates a new Invocation for the named transaction, optionally
 // pre-populated with environment values from the given profile.
 func (p *Protocol) Invoke(txName string, profile *string) (*Invocation, error) {

--- a/sdk/tx3sdk.go
+++ b/sdk/tx3sdk.go
@@ -20,6 +20,7 @@
 package tx3sdk
 
 import (
+	"github.com/tx3-lang/go-sdk/sdk/core"
 	"github.com/tx3-lang/go-sdk/sdk/facade"
 	"github.com/tx3-lang/go-sdk/sdk/signer"
 	"github.com/tx3-lang/go-sdk/sdk/tii"
@@ -58,10 +59,29 @@ func NewTRPClient(options TRPClientOptions) *trp.Client {
 // Tx3Client is the high-level entry point for building and submitting transactions.
 type Tx3Client = facade.Tx3Client
 
-// NewClient creates a new Tx3Client with the given protocol and TRP client.
-func NewClient(protocol *tii.Protocol, trpClient *trp.Client) *Tx3Client {
-	return facade.NewClient(protocol, trpClient)
+// Tx3ClientBuilder builds a Tx3Client. Obtained via Protocol.Client() or
+// facade.FromParts.
+type Tx3ClientBuilder = facade.Tx3ClientBuilder
+
+// ProtocolClient returns a fresh Tx3ClientBuilder seeded with the protocol's
+// transactions, profiles, and declared parties. Equivalent to
+// facade.FromProtocol(protocol). Idiomatic entry point for the dynamic flow.
+func ProtocolClient(protocol *tii.Protocol) *Tx3ClientBuilder {
+	return facade.FromProtocol(protocol)
 }
+
+// FromParts seeds a builder with already-deconstructed protocol fragments
+// (the codegen flow's entry point).
+func FromParts(
+	transactions map[string]core.TirEnvelope,
+	profiles map[string]facade.Profile,
+	knownParties []string,
+) *Tx3ClientBuilder {
+	return facade.FromParts(transactions, profiles, knownParties)
+}
+
+// Profile is the value type embedded in a Tx3Client's selected profile slot.
+type Profile = facade.Profile
 
 // TxBuilder collects transaction arguments and resolves the transaction.
 type TxBuilder = facade.TxBuilder


### PR DESCRIPTION
## Summary

Ports the unified-builder pattern from `rust-sdk` into go-sdk so the §3.3/§3.6 facade rows of [`sdks/parity-matrix.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/parity-matrix.md) flip ❌→✅.

- New `Tx3ClientBuilder` (with `facade.FromProtocol(p)` + `facade.FromParts(...)` seeders, `TRP` / `TRPEndpoint` / `WithHeader` / `WithProfile` / `WithParty` / `WithParties` / `WithPartyUnchecked` / `WithEnvValue` setters, single `Build() (*Tx3Client, error)` terminal).
- `Tx3Client` owns the deconstructed protocol parts; `WithProfile` is **builder-only** (removed from the built client per §3.6); `Tx(name)` returns `(*TxBuilder, error)` with `*tii.UnknownTxError` on miss.
- `TxBuilder` is **source-agnostic** — both dynamic and codegen flows drive the same `Resolve(ctx)` path.
- New `*facade.MissingTrpEndpointError` (with `isFacadeError()` marker).
- Codegen template (`.trix/client-lib/protocol.go.hbs`) wraps `facade.FromParts(...)`; per-party setters route through `WithPartyUnchecked`; profiles emitted with a typed `Profile` string-alias.
- Root-level re-exports: `tx3sdk.Tx3ClientBuilder`, `tx3sdk.Profile`, `tx3sdk.ProtocolClient`, `tx3sdk.FromParts`.

Spec references: [`sdks/sdk-spec/api-surface/facade.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/api-surface/facade.md) §3.3, §3.4, §3.6; [`sdks/sdk-spec/codegen/generated-surface.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/codegen/generated-surface.md) §C.3a–d.

## Note on naming

Go's strict import cycle prevented adding a `Protocol.Client()` method on `*tii.Protocol` — that would create `tii → facade → tii` (the builder must reference `*tii.Protocol` in its `FromProtocol` signature). Idiomatic Go uses the cross-package factory `facade.FromProtocol(p)`, also re-exported at the package root as `tx3sdk.ProtocolClient(p)`. Web-sdk and python-sdk do expose `Protocol.client()` — they don't have Go's strict cycle rule.

## Breaking changes

- `facade.NewClient(protocol, *trp.Client)` and `tx3sdk.NewClient` removed — use `tx3sdk.ProtocolClient(p).TRP(opts).Build()` instead.
- `Tx3Client.Tx(name)` signature change: `*TxBuilder` → `(*TxBuilder, error)`. Required by §3.3's recoverable-lookup mandate.
- `Tx3Client.WithParty(name, party)` signature change: `*Tx3Client` → `(*Tx3Client, error)`.
- `Tx3Client.WithProfile` removed (builder-only per §3.6).
- The package-doc example in `sdk/tx3sdk.go:1-20` still shows the old API — should be refreshed before release, but kept out of this PR to keep the diff scoped.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass (`./sdk`, `./core`, `./facade`, `./signer`, `./tii`, `./trp`)
- [x] `tx3c codegen` against `sdk/testdata/transfer.tii` renders all expected symbols (`Tx3ClientBuilder`, `FromParts`, `TransferParams`, `TRANSFER_TIR`, per-party `WithSender`/`WithReceiver`/`WithMiddleman`)
- [ ] **`codegen-check.sh` will fail in CI** until this lands and a new tag (`sdk/v…`) is published — the rendered `go.mod` pins `github.com/tx3-lang/go-sdk/sdk v0.11.0`, which doesn't have `Tx3ClientBuilder`. Expected for a template flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)