### PR TITLE
feat(codegen): render named types for protocol custom types

### DIFF
--- a/.trix/client-lib/protocol.go.hbs
+++ b/.trix/client-lib/protocol.go.hbs
@@ -45,6 +45,10 @@ var _{{constantCase @key}}_PROFILE = func() facade.Profile {
 {{/each}}
 
 {{/if}}
+{{#if tii.components.schemas}}
+// Named types for the protocol's custom (record / variant) types.
+{{{componentTypes tii.components.schemas "go"}}}
+{{/if}}
 {{#each tii.transactions}}
 // {{pascalCase @key}}Params holds the arguments for the {{@key}} transaction.
 type {{pascalCase @key}}Params struct {


### PR DESCRIPTION
## What

Declare a named type per `components.schemas` entry in the generated client:
a full struct/interface/dataclass for records, and a permissive named alias
for variants (pending the variant arg encoder).

Driven by the new `componentTypes` helper in `tx3c codegen`.

Pairs with `tx3-lang/tx3` (emitter + codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
