### PR TITLE
feat(tii)!: interpret the full complex param-type model

### DIFF
--- a/sdk/core/args.go
+++ b/sdk/core/args.go
@@ -112,6 +112,28 @@ func CoerceArg(v interface{}) (interface{}, error) {
 		return "0x" + hex.EncodeToString(val), nil
 	case *big.Int:
 		return BigIntArg(val).ToJSON(), nil
+	case []interface{}:
+		// list / tuple: coerce each element recursively.
+		out := make([]interface{}, len(val))
+		for i, e := range val {
+			c, err := CoerceArg(e)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = c
+		}
+		return out, nil
+	case map[string]interface{}:
+		// map / record: coerce each value recursively.
+		out := make(map[string]interface{}, len(val))
+		for k, e := range val {
+			c, err := CoerceArg(e)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = c
+		}
+		return out, nil
 	default:
 		return nil, fmt.Errorf("unsupported arg type: %T", v)
 	}

--- a/sdk/core/args_test.go
+++ b/sdk/core/args_test.go
@@ -100,6 +100,27 @@ func TestCoerceArgUnsupportedType(t *testing.T) {
 	}
 }
 
+func TestCoerceArgRecursesIntoCompounds(t *testing.T) {
+	// list/tuple: a []byte nested in a slice must still hex-encode.
+	got, err := core.CoerceArg([]interface{}{1, []byte{0xab, 0xcd}})
+	if err != nil {
+		t.Fatalf("CoerceArg list: %v", err)
+	}
+	list := got.([]interface{})
+	if list[0].(int64) != 1 || list[1].(string) != "0xabcd" {
+		t.Fatalf("unexpected list coercion: %#v", list)
+	}
+
+	// map/record: nested []byte value must hex-encode too.
+	got, err = core.CoerceArg(map[string]interface{}{"policy": []byte{0x01}})
+	if err != nil {
+		t.Fatalf("CoerceArg map: %v", err)
+	}
+	if got.(map[string]interface{})["policy"].(string) != "0x01" {
+		t.Fatalf("unexpected map coercion: %#v", got)
+	}
+}
+
 func TestNormalizeArgKey(t *testing.T) {
 	if core.NormalizeArgKey("Quantity") != "quantity" {
 		t.Error("expected lowercase")

--- a/sdk/errors_test.go
+++ b/sdk/errors_test.go
@@ -19,8 +19,6 @@ func TestErrorDiscriminationTII(t *testing.T) {
 	assertDiscriminable[*tii.InvalidJSONError](t, &tii.InvalidJSONError{Cause: fmt.Errorf("bad")})
 	assertDiscriminable[*tii.UnknownTxError](t, &tii.UnknownTxError{Name: "foo"})
 	assertDiscriminable[*tii.UnknownProfileError](t, &tii.UnknownProfileError{Name: "bar"})
-	assertDiscriminable[*tii.InvalidParamsSchemaError](t, &tii.InvalidParamsSchemaError{Detail: "bad"})
-	assertDiscriminable[*tii.InvalidParamTypeError](t, &tii.InvalidParamTypeError{Detail: "bad"})
 }
 
 func TestErrorDiscriminationTRP(t *testing.T) {
@@ -102,8 +100,6 @@ func TestTiiErrorMarker(t *testing.T) {
 	var _ tii.TiiError = &tii.InvalidJSONError{}
 	var _ tii.TiiError = &tii.UnknownTxError{}
 	var _ tii.TiiError = &tii.UnknownProfileError{}
-	var _ tii.TiiError = &tii.InvalidParamsSchemaError{}
-	var _ tii.TiiError = &tii.InvalidParamTypeError{}
 }
 
 // TestTrpErrorMarker verifies TRP errors implement TrpError interface.

--- a/sdk/testdata/complex.tii
+++ b/sdk/testdata/complex.tii
@@ -1,0 +1,119 @@
+{
+  "tii": {
+    "version": "v1beta0"
+  },
+  "protocol": {
+    "name": "complex-types",
+    "scope": "unknown",
+    "version": "0.0.1",
+    "description": "Schema-only fixture exercising every ParamType kind. The TIR envelope is a non-resolvable placeholder; this vector is for parameter-type interpretation tests, not TRP resolution."
+  },
+  "environment": {
+    "type": "object",
+    "properties": {
+      "fee": {
+        "type": "integer"
+      }
+    },
+    "required": ["fee"]
+  },
+  "parties": {
+    "sender": {},
+    "receiver": {}
+  },
+  "profiles": {
+    "local": {
+      "environment": {},
+      "parties": {}
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssetClass": {
+        "type": "object",
+        "properties": {
+          "policy": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" },
+          "name": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+        },
+        "required": ["policy", "name"]
+      },
+      "Side": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Buy"],
+            "properties": {
+              "Buy": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Sell"],
+            "properties": {
+              "Sell": {
+                "type": "object",
+                "properties": { "price": { "type": "integer" } },
+                "required": ["price"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "transactions": {
+    "complex": {
+      "params": {
+        "type": "object",
+        "properties": {
+          "quantity": { "type": "integer" },
+          "flag": { "type": "boolean" },
+          "nothing": { "type": "null" },
+          "recipient": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Address" },
+          "source": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/UtxoRef" },
+          "bag": { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/AnyAsset" },
+          "amounts": {
+            "type": "array",
+            "items": { "type": "integer" }
+          },
+          "pair": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "integer" },
+              { "$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes" }
+            ],
+            "items": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" }
+          },
+          "asset": { "$ref": "#/components/schemas/AssetClass" },
+          "side": { "$ref": "#/components/schemas/Side" }
+        },
+        "required": [
+          "quantity",
+          "flag",
+          "nothing",
+          "recipient",
+          "source",
+          "bag",
+          "amounts",
+          "pair",
+          "labels",
+          "asset",
+          "side"
+        ]
+      },
+      "tir": {
+        "content": "00",
+        "encoding": "hex",
+        "version": "v1beta0"
+      }
+    }
+  }
+}

--- a/sdk/tii/errors.go
+++ b/sdk/tii/errors.go
@@ -51,23 +51,3 @@ func (e *UnknownProfileError) Error() string {
 	return fmt.Sprintf("unknown profile: %q", e.Name)
 }
 func (e *UnknownProfileError) isTiiError() {}
-
-// InvalidParamsSchemaError indicates the transaction's params schema is malformed.
-type InvalidParamsSchemaError struct {
-	Detail string
-}
-
-func (e *InvalidParamsSchemaError) Error() string {
-	return fmt.Sprintf("invalid params schema: %s", e.Detail)
-}
-func (e *InvalidParamsSchemaError) isTiiError() {}
-
-// InvalidParamTypeError indicates an unrecognized parameter type in the schema.
-type InvalidParamTypeError struct {
-	Detail string
-}
-
-func (e *InvalidParamTypeError) Error() string {
-	return fmt.Sprintf("invalid param type: %s", e.Detail)
-}
-func (e *InvalidParamTypeError) isTiiError() {}

--- a/sdk/tii/param_type.go
+++ b/sdk/tii/param_type.go
@@ -81,34 +81,46 @@ func ParamTypeFromSchema(schema Schema, components map[string]Schema) ParamType 
 	case "null":
 		return ParamType{Kind: KindUnit}
 	case "array":
-		if len(schema.PrefixItems) > 0 {
-			elements := make([]ParamType, 0, len(schema.PrefixItems))
-			for _, el := range schema.PrefixItems {
-				elements = append(elements, ParamTypeFromSchema(el, components))
-			}
-			return ParamType{Kind: KindTuple, Elements: elements}
-		}
-		if schema.Items != nil {
-			inner := ParamTypeFromSchema(*schema.Items, components)
-			return ParamType{Kind: KindList, Inner: &inner}
-		}
-		return unknown(schema)
+		return arrayType(schema, components)
 	case "object":
-		if schema.AdditionalProperties != nil {
-			value := ParamTypeFromSchema(*schema.AdditionalProperties, components)
-			return ParamType{Kind: KindMap, Inner: &value}
-		}
-		if len(schema.Properties) > 0 {
-			fields := make(map[string]ParamType, len(schema.Properties))
-			for k, v := range schema.Properties {
-				fields[k] = ParamTypeFromSchema(v, components)
-			}
-			return ParamType{Kind: KindRecord, Fields: fields}
-		}
-		return unknown(schema)
+		return objectType(schema, components)
 	default:
 		return unknown(schema)
 	}
+}
+
+// arrayType interprets an "array" schema: prefixItems → Tuple, items → List,
+// neither → Unknown.
+func arrayType(schema Schema, components map[string]Schema) ParamType {
+	if len(schema.PrefixItems) > 0 {
+		elements := make([]ParamType, 0, len(schema.PrefixItems))
+		for _, el := range schema.PrefixItems {
+			elements = append(elements, ParamTypeFromSchema(el, components))
+		}
+		return ParamType{Kind: KindTuple, Elements: elements}
+	}
+	if schema.Items != nil {
+		inner := ParamTypeFromSchema(*schema.Items, components)
+		return ParamType{Kind: KindList, Inner: &inner}
+	}
+	return unknown(schema)
+}
+
+// objectType interprets an "object" schema: additionalProperties → Map,
+// properties → Record, neither → Unknown.
+func objectType(schema Schema, components map[string]Schema) ParamType {
+	if schema.AdditionalProperties != nil {
+		value := ParamTypeFromSchema(*schema.AdditionalProperties, components)
+		return ParamType{Kind: KindMap, Inner: &value}
+	}
+	if len(schema.Properties) > 0 {
+		fields := make(map[string]ParamType, len(schema.Properties))
+		for k, v := range schema.Properties {
+			fields[k] = ParamTypeFromSchema(v, components)
+		}
+		return ParamType{Kind: KindRecord, Fields: fields}
+	}
+	return unknown(schema)
 }
 
 // variantCase interprets one externally-tagged oneOf branch:

--- a/sdk/tii/param_type.go
+++ b/sdk/tii/param_type.go
@@ -2,68 +2,154 @@ package tii
 
 import "strings"
 
-// ParamType represents the type of a transaction parameter.
-type ParamType int
+// ParamKind identifies the category of a transaction parameter type.
+type ParamKind int
 
 const (
-	ParamTypeBytes   ParamType = iota // Hex-encoded byte array
-	ParamTypeInteger                  // Signed/unsigned integer
-	ParamTypeBoolean                  // Boolean
-	ParamTypeUtxoRef                  // UTxO reference "txid#index"
-	ParamTypeAddress                  // Bech32 address
-	ParamTypeList                     // List of another type
-	ParamTypeCustom                   // Custom JSON schema
+	KindBytes    ParamKind = iota // Hex-encoded byte array
+	KindInteger                   // Signed/unsigned integer
+	KindBoolean                   // Boolean
+	KindUnit                      // Unit ({"type":"null"})
+	KindUtxoRef                   // UTxO reference "txid#index"
+	KindAddress                   // Bech32 address
+	KindUtxo                      // Resolved UTxO object
+	KindAnyAsset                  // Asset identified by policy + name
+	KindList                      // Homogeneous sequence (array + items)
+	KindTuple                     // Positional sequence (array + prefixItems)
+	KindMap                       // String-keyed map (object + additionalProperties)
+	KindRecord                    // User record (object + properties)
+	KindVariant                   // User tagged union (oneOf)
+	KindUnknown                   // Unrecognized schema; carries the raw schema
 )
 
-// ParamInfo holds a parameter's name and type.
+// ParamType describes a transaction parameter's type. Compound kinds carry their
+// element/field types: List/Map in Inner, Tuple in Elements, Record in Fields,
+// Variant in Cases. Unknown carries the raw Schema.
+type ParamType struct {
+	Kind     ParamKind
+	Inner    *ParamType           // List element / Map value
+	Elements []ParamType          // Tuple positional types
+	Fields   map[string]ParamType // Record field name → type
+	Cases    []VariantCase        // Variant cases
+	Schema   *Schema              // Unknown fallback (raw schema)
+}
+
+// VariantCase is one case of a KindVariant param.
+type VariantCase struct {
+	Tag    string
+	Fields ParamType
+}
+
+// ParamInfo pairs a parameter name with its type.
 type ParamInfo struct {
 	Name string
 	Type ParamType
 }
 
-// tx3CoreTypePrefix is the base URI for Tx3 core type references.
-const tx3CoreTypePrefix = "https://tx3.land/specs/v1beta0/core#"
-
-// ParamTypeFromSchema derives a ParamType from a JSON schema definition.
-func ParamTypeFromSchema(schema Schema) (ParamType, error) {
-	// Check for $ref to Tx3 core types
+// ParamTypeFromSchema derives a ParamType from a JSON schema node. It never
+// fails: any shape it does not recognize — a bare string, an unresolved object,
+// an unknown $ref — becomes KindUnknown carrying the raw schema. components is
+// the TII's components.schemas table, used to resolve "#/components/schemas/<Name>"
+// references to user-defined record / variant types.
+func ParamTypeFromSchema(schema Schema, components map[string]Schema) ParamType {
 	if schema.Ref != "" {
-		return paramTypeFromRef(schema.Ref)
+		if name, ok := strings.CutPrefix(schema.Ref, "#/components/schemas/"); ok {
+			if resolved, found := components[name]; found {
+				return ParamTypeFromSchema(resolved, components)
+			}
+			return unknown(schema)
+		}
+		if kind, ok := coreKindFromRef(schema.Ref); ok {
+			return ParamType{Kind: kind}
+		}
+		return unknown(schema)
+	}
+
+	if len(schema.OneOf) > 0 {
+		cases := make([]VariantCase, 0, len(schema.OneOf))
+		for _, c := range schema.OneOf {
+			cases = append(cases, variantCase(c, components))
+		}
+		return ParamType{Kind: KindVariant, Cases: cases}
 	}
 
 	switch schema.Type {
 	case "integer":
-		return ParamTypeInteger, nil
+		return ParamType{Kind: KindInteger}
 	case "boolean":
-		return ParamTypeBoolean, nil
-	case "string":
-		return ParamTypeAddress, nil // default string type maps to address
+		return ParamType{Kind: KindBoolean}
+	case "null":
+		return ParamType{Kind: KindUnit}
 	case "array":
-		return ParamTypeList, nil
-	case "object":
-		return ParamTypeCustom, nil
-	default:
-		if schema.Type != "" {
-			return 0, &InvalidParamTypeError{Detail: "unknown type: " + schema.Type}
+		if len(schema.PrefixItems) > 0 {
+			elements := make([]ParamType, 0, len(schema.PrefixItems))
+			for _, el := range schema.PrefixItems {
+				elements = append(elements, ParamTypeFromSchema(el, components))
+			}
+			return ParamType{Kind: KindTuple, Elements: elements}
 		}
-		return ParamTypeCustom, nil
+		if schema.Items != nil {
+			inner := ParamTypeFromSchema(*schema.Items, components)
+			return ParamType{Kind: KindList, Inner: &inner}
+		}
+		return unknown(schema)
+	case "object":
+		if schema.AdditionalProperties != nil {
+			value := ParamTypeFromSchema(*schema.AdditionalProperties, components)
+			return ParamType{Kind: KindMap, Inner: &value}
+		}
+		if len(schema.Properties) > 0 {
+			fields := make(map[string]ParamType, len(schema.Properties))
+			for k, v := range schema.Properties {
+				fields[k] = ParamTypeFromSchema(v, components)
+			}
+			return ParamType{Kind: KindRecord, Fields: fields}
+		}
+		return unknown(schema)
+	default:
+		return unknown(schema)
 	}
 }
 
-func paramTypeFromRef(ref string) (ParamType, error) {
-	if !strings.HasPrefix(ref, tx3CoreTypePrefix) {
-		return ParamTypeCustom, nil
+// variantCase interprets one externally-tagged oneOf branch:
+// {required: ["Tag"], properties: {"Tag": <fields>}}.
+func variantCase(c Schema, components map[string]Schema) VariantCase {
+	tag := ""
+	if len(c.Required) > 0 {
+		tag = c.Required[0]
 	}
+	fields := unknown(c)
+	if f, ok := c.Properties[tag]; ok {
+		fields = ParamTypeFromSchema(f, components)
+	}
+	return VariantCase{Tag: tag, Fields: fields}
+}
 
-	typeName := strings.TrimPrefix(ref, tx3CoreTypePrefix)
-	switch typeName {
-	case "Bytes":
-		return ParamTypeBytes, nil
-	case "Address":
-		return ParamTypeAddress, nil
-	case "UtxoRef":
-		return ParamTypeUtxoRef, nil
-	default:
-		return 0, &InvalidParamTypeError{Detail: "unknown core type ref: " + typeName}
+// coreKindFromRef matches a built-in core type by the trailing name of its $ref,
+// so both the canonical ".../tii#/$defs/<Name>" and legacy ".../core#<Name>"
+// forms resolve.
+func coreKindFromRef(ref string) (ParamKind, bool) {
+	name := ref
+	if i := strings.LastIndexAny(ref, "#/"); i >= 0 {
+		name = ref[i+1:]
 	}
+	switch name {
+	case "Bytes":
+		return KindBytes, true
+	case "Address":
+		return KindAddress, true
+	case "UtxoRef":
+		return KindUtxoRef, true
+	case "Utxo":
+		return KindUtxo, true
+	case "AnyAsset":
+		return KindAnyAsset, true
+	default:
+		return 0, false
+	}
+}
+
+func unknown(schema Schema) ParamType {
+	s := schema
+	return ParamType{Kind: KindUnknown, Schema: &s}
 }

--- a/sdk/tii/param_type_test.go
+++ b/sdk/tii/param_type_test.go
@@ -1,0 +1,137 @@
+package tii
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// parse decodes a JSON schema literal into a Schema (exercising the custom
+// UnmarshalJSON, incl. the `items: false` / `additionalProperties: false` forms).
+func parse(t *testing.T, raw string) Schema {
+	t.Helper()
+	var s Schema
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("unmarshal schema %q: %v", raw, err)
+	}
+	return s
+}
+
+func kindOf(t *testing.T, raw string) ParamType {
+	return ParamTypeFromSchema(parse(t, raw), map[string]Schema{})
+}
+
+func TestParamPrimitivesAndUnit(t *testing.T) {
+	cases := map[string]ParamKind{
+		`{"type":"integer"}`: KindInteger,
+		`{"type":"boolean"}`: KindBoolean,
+		`{"type":"null"}`:    KindUnit,
+	}
+	for raw, want := range cases {
+		if got := kindOf(t, raw).Kind; got != want {
+			t.Errorf("%s: got kind %d, want %d", raw, got, want)
+		}
+	}
+}
+
+func TestParamCoreRefsBothForms(t *testing.T) {
+	forms := []func(string) string{
+		func(n string) string { return "https://tx3.land/specs/v1beta0/tii#/$defs/" + n },
+		func(n string) string { return "https://tx3.land/specs/v1beta0/core#" + n },
+	}
+	want := map[string]ParamKind{
+		"Bytes":    KindBytes,
+		"Address":  KindAddress,
+		"UtxoRef":  KindUtxoRef,
+		"Utxo":     KindUtxo,
+		"AnyAsset": KindAnyAsset,
+	}
+	for _, form := range forms {
+		for name, wantKind := range want {
+			schema := Schema{Ref: form(name)}
+			if got := ParamTypeFromSchema(schema, nil).Kind; got != wantKind {
+				t.Errorf("$ref %s: got kind %d, want %d", form(name), got, wantKind)
+			}
+		}
+	}
+}
+
+func TestParamListNested(t *testing.T) {
+	pt := kindOf(t, `{"type":"array","items":{"type":"array","items":{"type":"boolean"}}}`)
+	if pt.Kind != KindList || pt.Inner == nil {
+		t.Fatalf("expected list, got %+v", pt)
+	}
+	if pt.Inner.Kind != KindList || pt.Inner.Inner == nil || pt.Inner.Inner.Kind != KindBoolean {
+		t.Fatalf("expected list(list(bool)), got %+v", pt)
+	}
+}
+
+func TestParamTupleWithItemsFalse(t *testing.T) {
+	pt := kindOf(t, `{"type":"array","prefixItems":[{"type":"integer"},{"$ref":"https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}],"items":false}`)
+	if pt.Kind != KindTuple {
+		t.Fatalf("expected tuple, got %+v", pt)
+	}
+	if len(pt.Elements) != 2 || pt.Elements[0].Kind != KindInteger || pt.Elements[1].Kind != KindBytes {
+		t.Fatalf("unexpected tuple elements: %+v", pt.Elements)
+	}
+}
+
+func TestParamMap(t *testing.T) {
+	pt := kindOf(t, `{"type":"object","additionalProperties":{"type":"integer"}}`)
+	if pt.Kind != KindMap || pt.Inner == nil || pt.Inner.Kind != KindInteger {
+		t.Fatalf("expected map(int), got %+v", pt)
+	}
+}
+
+func TestParamRecord(t *testing.T) {
+	pt := kindOf(t, `{"type":"object","properties":{"price":{"type":"integer"},"live":{"type":"boolean"}},"required":["price","live"]}`)
+	if pt.Kind != KindRecord {
+		t.Fatalf("expected record, got %+v", pt)
+	}
+	if pt.Fields["price"].Kind != KindInteger || pt.Fields["live"].Kind != KindBoolean {
+		t.Fatalf("unexpected record fields: %+v", pt.Fields)
+	}
+}
+
+func TestParamVariant(t *testing.T) {
+	pt := kindOf(t, `{"oneOf":[
+		{"type":"object","additionalProperties":false,"required":["Buy"],"properties":{"Buy":{"type":"object","properties":{},"required":[]}}},
+		{"type":"object","additionalProperties":false,"required":["Sell"],"properties":{"Sell":{"type":"object","properties":{"price":{"type":"integer"}},"required":["price"]}}}
+	]}`)
+	if pt.Kind != KindVariant || len(pt.Cases) != 2 {
+		t.Fatalf("expected 2-case variant, got %+v", pt)
+	}
+	if pt.Cases[0].Tag != "Buy" || pt.Cases[1].Tag != "Sell" {
+		t.Fatalf("unexpected variant tags: %q, %q", pt.Cases[0].Tag, pt.Cases[1].Tag)
+	}
+	if pt.Cases[1].Fields.Kind != KindRecord || pt.Cases[1].Fields.Fields["price"].Kind != KindInteger {
+		t.Fatalf("unexpected Sell fields: %+v", pt.Cases[1].Fields)
+	}
+}
+
+func TestParamComponentRefResolves(t *testing.T) {
+	components := map[string]Schema{
+		"AssetClass": parse(t, `{"type":"object","properties":{"policy":{"$ref":"https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"}},"required":["policy"]}`),
+	}
+	pt := ParamTypeFromSchema(Schema{Ref: "#/components/schemas/AssetClass"}, components)
+	if pt.Kind != KindRecord || pt.Fields["policy"].Kind != KindBytes {
+		t.Fatalf("expected record(policy:bytes), got %+v", pt)
+	}
+	// Missing component → Unknown, never errors.
+	miss := ParamTypeFromSchema(Schema{Ref: "#/components/schemas/Nope"}, components)
+	if miss.Kind != KindUnknown {
+		t.Fatalf("expected unknown for missing component, got %+v", miss)
+	}
+}
+
+func TestParamUnknownNeverFails(t *testing.T) {
+	for _, raw := range []string{
+		`{"type":"string"}`,
+		`{}`,
+		`{"type":"array"}`,
+		`{"$ref":"https://example.com/Weird"}`,
+	} {
+		if got := kindOf(t, raw).Kind; got != KindUnknown {
+			t.Errorf("%s: expected unknown, got kind %d", raw, got)
+		}
+	}
+}

--- a/sdk/tii/protocol.go
+++ b/sdk/tii/protocol.go
@@ -4,6 +4,7 @@ package tii
 import (
 	"encoding/json"
 	"os"
+	"strings"
 )
 
 // Protocol is the in-memory representation of a loaded TII file.
@@ -74,14 +75,29 @@ func (p *Protocol) Invoke(txName string, profile *string) (*Invocation, error) {
 		return nil, &UnknownTxError{Name: txName}
 	}
 
-	// Extract param types from the transaction schema
+	// User-defined record / variant schemas referenced by param $refs.
+	components := map[string]Schema{}
+	if p.spec.Components != nil {
+		components = p.spec.Components.Schemas
+	}
+
 	params := make(map[string]ParamType)
-	for name, schema := range tx.Params.Properties {
-		pt, err := ParamTypeFromSchema(schema)
-		if err != nil {
-			return nil, err
+
+	// Party addresses are implicit Address params.
+	for name := range p.spec.Parties {
+		params[strings.ToLower(name)] = ParamType{Kind: KindAddress}
+	}
+
+	// Protocol-level environment params.
+	if p.spec.Environment != nil {
+		for name, schema := range p.spec.Environment.Properties {
+			params[name] = ParamTypeFromSchema(schema, components)
 		}
-		params[name] = pt
+	}
+
+	// Transaction params.
+	for name, schema := range tx.Params.Properties {
+		params[name] = ParamTypeFromSchema(schema, components)
 	}
 
 	// Build required set

--- a/sdk/tii/protocol_test.go
+++ b/sdk/tii/protocol_test.go
@@ -144,6 +144,64 @@ func TestInvokeWithProfile(t *testing.T) {
 	}
 }
 
+// TestInvokeInterpretsComplexParams locks in the Protocol.Invoke path that the
+// unit tests can't reach: threading spec.Components into ParamTypeFromSchema,
+// and exposing party (Address) and environment-schema params. Asserts a real
+// complex.tii produces the expected compound kinds, incl. a component-$ref Record.
+func TestInvokeInterpretsComplexParams(t *testing.T) {
+	p, err := tii.FromFile("../testdata/complex.tii")
+	if err != nil {
+		t.Fatalf("FromFile failed: %v", err)
+	}
+
+	inv, err := p.Invoke("complex", nil)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	params := inv.Params()
+
+	wantKind := map[string]tii.ParamKind{
+		"quantity":  tii.KindInteger,
+		"flag":      tii.KindBoolean,
+		"nothing":   tii.KindUnit,
+		"recipient": tii.KindAddress,
+		"source":    tii.KindUtxoRef,
+		"bag":       tii.KindAnyAsset,
+		"amounts":   tii.KindList,
+		"pair":      tii.KindTuple,
+		"labels":    tii.KindMap,
+		"asset":     tii.KindRecord,
+		"side":      tii.KindVariant,
+		// Parties surface as implicit Address params (lowercased).
+		"sender":   tii.KindAddress,
+		"receiver": tii.KindAddress,
+		// Protocol-level environment schema params.
+		"fee": tii.KindInteger,
+	}
+	for name, want := range wantKind {
+		got, ok := params[name]
+		if !ok {
+			t.Errorf("missing param %q", name)
+			continue
+		}
+		if got.Kind != want {
+			t.Errorf("param %q: got kind %d, want %d", name, got.Kind, want)
+		}
+	}
+
+	// The component-$ref Record must have resolved its inner Bytes field — this
+	// is the assertion that actually guards the spec.Components threading.
+	asset := params["asset"]
+	if asset.Fields["policy"].Kind != tii.KindBytes {
+		t.Errorf("asset.policy: got kind %d, want Bytes", asset.Fields["policy"].Kind)
+	}
+
+	// The component-$ref Variant must have resolved its cases.
+	if side := params["side"]; len(side.Cases) != 2 {
+		t.Errorf("side: got %d cases, want 2", len(side.Cases))
+	}
+}
+
 func assertProtocolValid(t *testing.T, p *tii.Protocol) {
 	t.Helper()
 

--- a/sdk/tii/spec.go
+++ b/sdk/tii/spec.go
@@ -1,6 +1,9 @@
 package tii
 
 import (
+	"bytes"
+	"encoding/json"
+
 	"github.com/tx3-lang/go-sdk/sdk/core"
 )
 
@@ -12,6 +15,13 @@ type TiiFile struct {
 	Parties      map[string]PartySpec   `json:"parties"`
 	Transactions map[string]Transaction `json:"transactions"`
 	Profiles     map[string]Profile     `json:"profiles"`
+	Components   *Components            `json:"components,omitempty"`
+}
+
+// Components holds the reusable schemas referenced by
+// "#/components/schemas/<Name>" param refs (user-defined records / variants).
+type Components struct {
+	Schemas map[string]Schema `json:"schemas"`
 }
 
 // TiiInfo holds TII format version metadata.
@@ -48,9 +58,58 @@ type Profile struct {
 // Schema is a JSON Schema object used for parameter definitions.
 // We use a thin wrapper to support type introspection.
 type Schema struct {
-	Type       string            `json:"type,omitempty"`
-	Properties map[string]Schema `json:"properties,omitempty"`
-	Required   []string          `json:"required,omitempty"`
-	Ref        string            `json:"$ref,omitempty"`
-	Items      *Schema           `json:"items,omitempty"`
+	Type                 string            `json:"type,omitempty"`
+	Properties           map[string]Schema `json:"properties,omitempty"`
+	Required             []string          `json:"required,omitempty"`
+	Ref                  string            `json:"$ref,omitempty"`
+	Items                *Schema           `json:"items,omitempty"`
+	PrefixItems          []Schema          `json:"prefixItems,omitempty"`
+	AdditionalProperties *Schema           `json:"additionalProperties,omitempty"`
+	OneOf                []Schema          `json:"oneOf,omitempty"`
+}
+
+// UnmarshalJSON decodes a Schema, tolerating the boolean forms `tx3c` emits for
+// `items` (a tuple sets `"items": false`) and `additionalProperties` (a variant
+// case sets `"additionalProperties": false`). A `*Schema` field cannot decode a
+// bare `false`, so those keys are only populated when they hold a schema object.
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	type rawSchema struct {
+		Type                 string            `json:"type"`
+		Properties           map[string]Schema `json:"properties"`
+		Required             []string          `json:"required"`
+		Ref                  string            `json:"$ref"`
+		Items                json.RawMessage   `json:"items"`
+		PrefixItems          []Schema          `json:"prefixItems"`
+		AdditionalProperties json.RawMessage   `json:"additionalProperties"`
+		OneOf                []Schema          `json:"oneOf"`
+	}
+
+	var raw rawSchema
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	s.Type = raw.Type
+	s.Properties = raw.Properties
+	s.Required = raw.Required
+	s.Ref = raw.Ref
+	s.PrefixItems = raw.PrefixItems
+	s.OneOf = raw.OneOf
+	s.Items = objectSchema(raw.Items)
+	s.AdditionalProperties = objectSchema(raw.AdditionalProperties)
+	return nil
+}
+
+// objectSchema decodes a JSON value into a *Schema only when it is an object,
+// returning nil for the boolean / absent forms (e.g. `items: false`).
+func objectSchema(raw json.RawMessage) *Schema {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil
+	}
+	var sub Schema
+	if err := json.Unmarshal(trimmed, &sub); err != nil {
+		return nil
+	}
+	return &sub
 }


### PR DESCRIPTION
## Summary

Reworks `ParamType` to interpret every shape `tx3c` emits into the TII params schema, per the canonical model in the SDK spec's `api-surface/args.md`. The go-sdk slice of a cross-fleet complex-type parity effort (rust/go/python/web).

## Changes

- **Flat `int` enum → struct** carrying element/field types (`Inner`/`Elements`/`Fields`/`Cases`/`Schema`); adds `Unit`/`Utxo`/`AnyAsset`/`Map`/`Record`/`Variant`/`Unknown` kinds.
- **Trailing-name `$ref` matching** across `tii#/$defs/` and legacy `core#` forms (previously non-core refs silently degraded to custom, losing Bytes/Address/UtxoRef typing); drops the latent `string`→Address default.
- **Never fails** — unrecognized shapes become `Unknown`; resolves `#/components/schemas/<Name>` refs.
- **Custom `Schema.UnmarshalJSON`** so the `items: false` (tuple) and `additionalProperties: false` (variant-case) forms `tx3c` emits parse instead of failing `FromBytes` (a `*Schema` cannot decode a bare `false`). Adds `PrefixItems`/`AdditionalProperties`/`OneOf` and `TiiFile.Components`.
- **`CoerceArg` recurses** into `[]interface{}` and `map[string]interface{}` so nested bytes/bigint coerce.
- **`Protocol.Invoke`** now also exposes party (Address) and environment-schema params, matching the reference SDK.

## Tests

`go test ./...` — all pass (new `param_type_test.go` over the full canonical table incl. both ref forms, nested compounds, component resolution, `items:false`/`additionalProperties:false` parsing, never-fail fallbacks; new `CoerceArg` recursion cases). `go vet` + `gofmt` clean on changed files.

Validated against the shared fixture `sdk-spec/test-vectors/complex-types/complex.tii` (identical kind map vs the python loader).

## Breaking change

`ParamType` becomes a struct and the `ParamType*` constants are replaced by `ParamKind` (`KindBytes`, …); `ParamTypeFromSchema` takes a components map and no longer returns an error. Needs a version bump per `sdk-spec/release-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)