### PR TITLE
chore: release 0.13.0

### DIFF
--- a/.trix/client-lib/go.mod.hbs
+++ b/.trix/client-lib/go.mod.hbs
@@ -2,4 +2,4 @@ module {{tii.protocol.name}}
 
 go 1.24.2
 
-require github.com/tx3-lang/go-sdk/sdk v0.12.0
+require github.com/tx3-lang/go-sdk/sdk v0.13.0


### PR DESCRIPTION
Release-prep for the coordinated **0.13.0** SDK fleet train.

All four SDKs carry the unreleased breaking `feat(tii)!: interpret the full complex param-type model` change on top of the already-tagged `v0.12.0`. Per `sdk-spec/versioning.md` + `release-policy.md`, a breaking TII change forces at minimum a coordinated minor bump across the fleet, and `0.12.0` can't be reused — so the train moves to `0.13.0`.

This PR bumps the package version and the `.trix/client-lib` codegen template's pinned SDK requirement **in the same commit** (required by `sdk-spec/codegen/versioning.md` — the template requirement must not get ahead of the source version).

Merging this is the prerequisite for tagging the release (`release.yml` validates `tag == manifest version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)